### PR TITLE
Adding a unique id for developers.redhat.com

### DIFF
--- a/demo.yaml
+++ b/demo.yaml
@@ -1,3 +1,4 @@
+id: continuous-delivery-eap
 title: Continuous delivery demo using JBoss EAP
 github_repo_url: https://github.com/jbossdemocentral/continuous-delivery-demo
 technologies:


### PR DESCRIPTION
We need a unique id (there's one other demo which uses demo.yaml and also does not have an id in the file) for demos to have them properly listed on the site.
